### PR TITLE
Bug 457729 - fix undefine in argument.js

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/examplePages/singlepane.html
+++ b/bundles/org.eclipse.orion.client.ui/web/examplePages/singlepane.html
@@ -9,6 +9,7 @@
 		<link rel="stylesheet" type="text/css" href="singlepane.css" />
     	<script type="text/javascript" src="../requirejs/require.js"></script>
 		<script type="text/javascript">
+		/*eslint-env node */
 		require({
 			  baseUrl: '..',
 			  packages: [ ],

--- a/bundles/org.eclipse.orion.client.ui/web/examplePages/singlepane.html
+++ b/bundles/org.eclipse.orion.client.ui/web/examplePages/singlepane.html
@@ -9,7 +9,6 @@
 		<link rel="stylesheet" type="text/css" href="singlepane.css" />
     	<script type="text/javascript" src="../requirejs/require.js"></script>
 		<script type="text/javascript">
-		/*eslint-env node */
 		require({
 			  baseUrl: '..',
 			  packages: [ ],

--- a/bundles/org.eclipse.orion.client.ui/web/gcli/gcli/argument.js
+++ b/bundles/org.eclipse.orion.client.ui/web/gcli/gcli/argument.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-define(function(require, exports, module) {
+/*eslint-env amd, node*/
+define(/* @callback */ function(require, exports, module) {
 
 'use strict';
 
@@ -93,7 +94,7 @@ Argument.prototype.beget = function(options) {
 
     // We need to add quotes when the replacement string has spaces or is empty
     if (!options.dontQuote) {
-      var needsQuote = text.indexOf(' ') >= 0 || text.length == 0;
+      var needsQuote = text.indexOf(' ') >= 0 || text.length === 0;
       var hasQuote = /['"]$/.test(prefix);
       if (needsQuote && !hasQuote) {
         prefix = prefix + '\'';


### PR DESCRIPTION
Bug 457729 - fix undefine in argument.js

Fix the bug: 'define' is undefined.
-define(function(require, exports, module) 
+/*eslint-env amd, node*/
+define(/* @callback */ function(require, exports, module) 

Fix the bug: 'console' is undefined.
-      var needsQuote = text.indexOf(' ') >= 0 || text.length == 0;
+      var needsQuote = text.indexOf(' ') >= 0 || text.length === 0;

Signed-off-by: TianThea<thea.yier@outlook.com>