### PR TITLE
bug 457728 - Fix global undefine in util.js

### DIFF
--- a/bundles/org.eclipse.orion.client.git/web/orion/git/util.js
+++ b/bundles/org.eclipse.orion.client.git/web/orion/git/util.js
@@ -61,7 +61,7 @@ define([
 		}
 		return false;
 	}
-
+	/*globals URL*/
 	/* parses ssh gitUrl to get hostname and port */
 	function parseSshGitUrl(gitUrl){
 		try {


### PR DESCRIPTION
Bug 457728 -Fix global undefine in util.js
 Fix the bug said "URL is not defined" in line 69.
 Just add	/*globals URL*/ in line 64.

Signed-off-by: zhangchao <zhch040200@163.com>