### PR TITLE
Added Islamic and Hebrew calendar support

### DIFF
--- a/bundles/org.eclipse.orion.client.git/web/orion/git/widgets/gitCommitInfo.js
+++ b/bundles/org.eclipse.orion.client.git/web/orion/git/widgets/gitCommitInfo.js
@@ -18,8 +18,9 @@ define([
 	'orion/i18nUtil',
 	'orion/git/util',
 	'orion/objects',
-	'orion/bidiUtils'
-], function(require, messages, URITemplate, i18nUtil, util, objects, bidiUtils) {
+	'orion/bidiUtils',
+	'orion/calendarSupport'
+], function(require, messages, URITemplate, i18nUtil, util, objects, bidiUtils, calendarSupport) {
 	
 	var commitTemplate = new URITemplate("git/git-repository.html#{,resource,params*}?page=1"); //$NON-NLS-0$	
 	
@@ -156,7 +157,7 @@ define([
 					commitAuthorName = bidiUtils.enforceTextDirWithUcc(commitAuthorName);
 				}
 				var authorName = this.showAuthorEmail ? i18nUtil.formatMessage(messages["nameEmail"], commitAuthorName, commit.AuthorEmail) : commitAuthorName;
-				createInfo(detailsDiv, ["", "on"], [authorName, new Date(commit.Time).toLocaleString()]); //$NON-NLS-1$ //$NON-NLS-0$
+				createInfo(detailsDiv, ["", "on"], [authorName, new Date(commit.Time).toLocaleString(calendarSupport.calendarLocale)]); //$NON-NLS-1$ //$NON-NLS-0$
 			}
 			
 			if (displayCommitter) {

--- a/bundles/org.eclipse.orion.client.ui/web/orion/calendarSupport.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/calendarSupport.js
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+define (['orion/widgets/settings/GlobalizationSettings'],function(GlobalizationSettings){ /* ACGC */
+
+	var calendarTypeStorage = "/orion/preferences/bidi/calendarType"; //$NON-NLS-0$	
+
+	var calendarType = getCalendarType();
+	var calendarLocale = getCalendarLocale();
+
+	/**
+	 * returns calendarType value set in globalization settings.
+	 * @returns {String} calendar type.
+	 */	
+	function getCalendarType() {
+		var calendarType = localStorage.getItem(calendarTypeStorage);
+		if (calendarType) {	
+			return calendarType;
+		}
+		else {
+			return 'gregorian';	//$NON-NLS-0$
+		}
+	}
+	
+	/**
+	 * returns calendarLocale value based on calendar type.
+	 * @returns {String} calendar locale.
+	 */	
+	function getCalendarLocale() {
+		var calendarLocale = 'null'; //$NON-NLS-0$
+		if (calendarType == 'islamic') {	//$NON-NLS-0$
+			calendarLocale = 'ar-EG-u-ca-islamic'; //$NON-NLS-0$
+			return calendarLocale;
+		}
+		else if (calendarType == 'hebrew'){ //$NON-NLS-0$
+			calendarLocale = 'he-u-ca-hebrew'; //$NON-NLS-0$
+			return calendarLocale;
+		}
+		else { //return default locale
+			return calendarLocale; 
+		}
+	}	
+
+	return {
+		calendarLocale : calendarLocale
+	};
+
+	
+});

--- a/bundles/org.eclipse.orion.client.ui/web/orion/explorers/navigatorRenderer.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/explorers/navigatorRenderer.js
@@ -19,8 +19,9 @@ define([
 	'orion/URITemplate',
 	'orion/contentTypes',
 	'orion/webui/littlelib',
-	'orion/bidiUtils'
-], function(messages, Deferred, mExplorer, mNavUtils, mExtensionCommands, objects, URITemplate, mContentTypes, lib, bidiUtils) {
+	'orion/bidiUtils',
+	'orion/calendarSupport'
+], function(messages, Deferred, mExplorer, mNavUtils, mExtensionCommands, objects, URITemplate, mContentTypes, lib, bidiUtils, calendarSupport) {
 		
 	var max_more_info_column_length = 60;
 	/* Internal */
@@ -202,7 +203,7 @@ define([
 	 * @param {int|string} the local time stamp
 	 */
 	NavigatorRenderer.prototype.getDisplayTime = function(timeStamp) {
-		return new Date(timeStamp).toLocaleString();
+		return new Date(timeStamp).toLocaleString(calendarSupport.calendarLocale);
 	};
 	
 	/**

--- a/bundles/org.eclipse.orion.client.ui/web/orion/settings/nls/root/messages.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/settings/nls/root/messages.js
@@ -18,6 +18,7 @@ define({//Default message bundle
 	"Auto direction": "Auto direction",
 	"Gregorian": "Gregorian",
 	"Hebrew": "Hebrew",
+	"Islamic": "Islamic",
 	"Plugin Description": "Plug-in Description",
 	"Create": "Create",
 	"Loading...": "Loading...",

--- a/bundles/org.eclipse.orion.client.ui/web/orion/widgets/settings/GlobalizationSettings.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/widgets/settings/GlobalizationSettings.js
@@ -15,7 +15,8 @@ define([
 	
 	var CALENDAR_TYPES = [
 		         		{value: "gregorian", label: messages.Gregorian}, //$NON-NLS-0$
-		         		{value: "hebrew", label: messages.Hebrew} //$NON-NLS-0$
+		         		{value: "hebrew", label: messages.Hebrew}, //$NON-NLS-0$
+		         		{value: "islamic", label: messages.Islamic} //$NON-NLS-0$
 		         	];
 	
 	var bidiEnabled = "bidiEnabled"; //$NON-NLS-0$


### PR DESCRIPTION
We added support for Islamic and Hebrew Calendar

Please refer to: Bug 433595 - BIDI Hebrew Calendar is not supported in the date stamps 
https://bugs.eclipse.org/bugs/show_bug.cgi?id=255527